### PR TITLE
ci: add send slack message on deployment failure

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -12,11 +12,22 @@ jobs:
       - run: cd stable && flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_STABLE }}
-  experimental:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: cd experimental && flyctl deploy --remote-only
+      - if: failure()
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          channel-id: filecoin-station-incidents
+          payload: |
+            {
+              "text": "Deployment of `${{ github.event.repository.name }}` failed",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":warning: *<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Deployment of `${{ github.event.repository.name }}` failed>*"
+                  }
+                }
+              ]
+            }
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_EXPERIMENTAL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
Also remove outdated `experimental` deploy job

For https://github.com/filecoin-station/roadmap/issues/69