### PR TITLE
chore: Revert "remove `--experimental` deployment (#11)" and update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,15 @@ updates:
     reviewers:
       - "bajtos"
       - "juliangruber"
+  - package-ecosystem: "docker"
+    directory: "/experimental"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/Berlin"
+    reviewers:
+      - "bajtos"
+      - "juliangruber"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -31,3 +31,31 @@ jobs:
                 }
               ]
             }
+  experimental:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: cd stable && flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_STABLE }}
+      - if: failure()
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "alerts",
+              "text": "Deployment of `${{ github.event.repository.name }}` failed",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":warning: *<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Deployment of `${{ github.event.repository.name }}` failed>*"
+                  }
+                }
+              ]
+            }
+

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ $ fly deploy
 
 Deployments:
 - [`stable`](https://fly.io/apps/core-fly)
-- [`experimental`](https://fly.io/apps/core-fly-experimental) (`$ station --experimental`)
+- [`experimental`](https://fly.io/apps/node-fly-experimental) (`$ station --experimental`)

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ $ fly deploy
 
 Deployments:
 - [`stable`](https://fly.io/apps/core-fly)
-<!--- [`experimental`](https://fly.io/apps/core-fly-experimental) (`$ station --experimental`)-->
+- [`experimental`](https://fly.io/apps/core-fly-experimental) (`$ station --experimental`)

--- a/experimental/Dockerfile
+++ b/experimental/Dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/filecoin-station/core:18.0.0
-ENV FIL_WALLET_ADDRESS=0x000000000000000000000000000000000000dEaD
+FROM ghcr.io/checkernetwork/node:22.1.1
+ENV FIL_WALLET_ADDRESS=0x802720eeca89AD84b2d91c71f9Dc29052574769E
 CMD [ "./bin/station.js", "--experimental" ]

--- a/experimental/Dockerfile
+++ b/experimental/Dockerfile
@@ -1,0 +1,3 @@
+FROM ghcr.io/filecoin-station/core:18.0.0
+ENV FIL_WALLET_ADDRESS=0x000000000000000000000000000000000000dEaD
+CMD [ "./bin/station.js", "--experimental" ]

--- a/experimental/Dockerfile
+++ b/experimental/Dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/checkernetwork/node:22.1.1
+FROM ghcr.io/checkernetwork/node:22.1.2
 ENV FIL_WALLET_ADDRESS=0x802720eeca89AD84b2d91c71f9Dc29052574769E
 CMD [ "./bin/checker.js", "--experimental" ]

--- a/experimental/Dockerfile
+++ b/experimental/Dockerfile
@@ -1,3 +1,3 @@
 FROM ghcr.io/checkernetwork/node:22.1.1
 ENV FIL_WALLET_ADDRESS=0x802720eeca89AD84b2d91c71f9Dc29052574769E
-CMD [ "./bin/station.js", "--experimental" ]
+CMD [ "./bin/checker.js", "--experimental" ]

--- a/experimental/Dockerfile
+++ b/experimental/Dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/checkernetwork/node:22.1.2
+FROM ghcr.io/checkernetwork/node:22.2.0
 ENV FIL_WALLET_ADDRESS=0x802720eeca89AD84b2d91c71f9Dc29052574769E
 CMD [ "./bin/checker.js", "--experimental" ]

--- a/experimental/fly.toml
+++ b/experimental/fly.toml
@@ -1,0 +1,7 @@
+# fly.toml app configuration file generated for core-fly-experimental on 2023-05-30T11:05:00+02:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = "core-fly-experimental"
+primary_region = "cdg"

--- a/experimental/fly.toml
+++ b/experimental/fly.toml
@@ -1,7 +1,7 @@
-# fly.toml app configuration file generated for core-fly-experimental on 2023-05-30T11:05:00+02:00
+# fly.toml app configuration file generated for node-fly-experimental on 2023-05-30T11:05:00+02:00
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-app = "core-fly-experimental"
+app = "node-fly-experimental"
 primary_region = "cdg"


### PR DESCRIPTION
This reverts commit 8844724c7974981d5df2beeaa50d39a96dc2951f and updates experimental deployment name, base docker image and wallet.