### PR TITLE
fix: Pass down correct token to experimental deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,7 +38,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: cd experimental && flyctl deploy --remote-only
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_STABLE }}
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_EXPERIMENTAL }}
       - if: failure()
         uses: slackapi/slack-github-action@v2.0.0
         with:


### PR DESCRIPTION
Fixes failing github actions deployment for experimental node by passing down correct fly.io API token.